### PR TITLE
Add date sorting option

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,13 @@
   <main>
     <section id="events" class="active">
       <h2>Wydarzenia</h2>
+      <div class="sort-control">
+        <label for="sort-select">Sortuj:</label>
+        <select id="sort-select">
+          <option value="default">Domyślnie</option>
+          <option value="date">Według daty</option>
+        </select>
+      </div>
       <ul id="events-list"></ul>
     </section>
     <section id="premieres">
@@ -55,6 +62,18 @@
       document.getElementById('modal').classList.add('active');
     }
 
+    const months = {
+      'stycznia': 0, 'lutego': 1, 'marca': 2, 'kwietnia': 3,
+      'maja': 4, 'czerwca': 5, 'lipca': 6, 'sierpnia': 7,
+      'września': 8, 'października': 9, 'listopada': 10, 'grudnia': 11
+    };
+
+    function parseDate(str) {
+      const m = str.match(/(\d{1,2})\s+(stycznia|lutego|marca|kwietnia|maja|czerwca|lipca|sierpnia|września|października|listopada|grudnia)\s+(\d{4})/);
+      if (!m) return new Date(0);
+      return new Date(parseInt(m[3], 10), months[m[2]], parseInt(m[1], 10));
+    }
+
     function createItem(item, withVer) {
       const li = document.createElement('li');
       const text = withVer ? `${item.title} (${item.version})` : `${item.title} – ${item.date}`;
@@ -69,6 +88,7 @@
     }
 
     async function render() {
+      const sortByDate = document.getElementById('sort-select').value === 'date';
       for (const e of endpoints) {
         const list = await fetchData(e.url);
         const ul = document.getElementById(e.id);
@@ -82,6 +102,9 @@
           });
 
           Object.keys(grouped).forEach(category => {
+            if (sortByDate) {
+              grouped[category].sort((a, b) => parseDate(a.date) - parseDate(b.date));
+            }
             const catHeader = document.createElement('li');
             catHeader.textContent = category;
             catHeader.classList.add('bold-category');
@@ -92,6 +115,9 @@
             });
           });
         } else {
+          if (sortByDate && list.length && list[0].date) {
+            list.sort((a, b) => parseDate(a.date) - parseDate(b.date));
+          }
           list.forEach(i => ul.appendChild(createItem(i, e.ver)));
         }
       }
@@ -119,11 +145,12 @@
       });
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
-      render();
-      setupTabs();
-      setupModal();
-    });
+      document.addEventListener('DOMContentLoaded', () => {
+        render();
+        setupTabs();
+        setupModal();
+        document.getElementById('sort-select').addEventListener('change', render);
+      });
   </script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -115,6 +115,14 @@ li.bold-category {
   border-radius: 4px;
 }
 
+.sort-control {
+  margin-bottom: 1rem;
+}
+
+.sort-control label {
+  margin-right: .5rem;
+}
+
 .modal {
   display: none;
   position: fixed;


### PR DESCRIPTION
## Summary
- allow sorting events and premieres lists by date
- add UI select for sort option

## Testing
- `node server.js` (manual)
- `curl -s http://localhost:3000/api/events | head -c 80`

------
https://chatgpt.com/codex/tasks/task_e_6861103094ec8329adae0ee14c15bd7a