### PR TITLE
Fix remaining trailer placeholders

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,38 +1,201 @@
 {
   "events": [
-    {"category":"Filmowe Poranki","title":"Strażak Sam, cz. 5","date":"niedziela, 20 lipca 2025","description":"Kolejna część przygód dzielnego Strażaka Sama i jego przyjaciół."},
-    {"category":"Kino Konesera","title":"Małe miłości","date":"poniedziałek, 30 czerwca 2025","description":"Poruszająca historia o relacjach międzypokoleniowych i samotności."},
-    {"category":"Maraton Filmowy","title":"Maraton Władcy Pierścieni","date":"piątek, 22 sierpnia 2025","description":"Epoka podróż po Śródziemiu w filmowej trylogii Petera Jacksona."},
-    {"category":"Kino Kobiet","title":"Materialiści","date":"środa, 9 lipca 2025","description":"Komedia romantyczna o swatce, która spełnia marzenia klientów."},
-    {"category":"Kultura Dostępna","title":"Dziadku, wiejemy!","date":"czwartek, 3 lipca 2025","description":"Ciepła opowieść o relacji dziadka i córki oraz odwadze zmian."},
-    {"category":"Helios dla Dzieci","title":"Basia. Mam swój świat","date":"sobota, 5 lipca 2025","description":"Przedpremierowe seanse przygód rezolutnej Basi."},
-    {"category":"Helios Anime","title":"Szopy w natarciu","date":"niedziela, 13 lipca 2025","description":"Ekologiczna przypowieść Studia Ghibli o przyjaźni z naturą."},
-    {"category":"Helios Anime","title":"AKIRA","date":"środa, 16 lipca 2025","description":"Kultowy film anime o Neo Tokio po wojnie nuklearnej."},
-    {"category":"Helios na Scenie","title":"Dziewczyna z Kolonii","date":"sobota, 19 lipca 2025","description":"Muzyczna podróż z jazzowym pianistą w tle."},
-    {"category":"Maraton Filmowy","title":"Harry Potter: Mini Maraton cz. 1–2","date":"piątek, 4 lipca 2025","description":"Pokazy Kamień Filozoficzny i Komnata Tajemnic na dużym ekranie."},
-    {"category":"Maraton Filmowy","title":"Harry Potter: Mini Maraton cz. 3–4","date":"piątek, 18 lipca 2025","description":"Seanse Więzień Azkabanu i Czara Ognia dla fanów przygód czarodziejów."},
-    {"category":"Maraton Filmowy","title":"Harry Potter: Mini Maraton cz. 5–6","date":"piątek, 1 sierpnia 2025","description":"Pokazy Zakon Feniksa i Księcia Półkrwi w klimatycznej atmosferze."},
-    {"category":"Maraton Filmowy","title":"Harry Potter: Mini Maraton cz. 7–8","date":"piątek, 15 sierpnia 2025","description":"Finałowa odsłona maratonu z Insygniami Śmierci cz. 1 i 2."}
+    {
+      "category": "Filmowe Poranki",
+      "title": "Strażak Sam, cz. 5",
+      "date": "niedziela, 20 lipca 2025",
+      "description": "Kolejna część przygód dzielnego Strażaka Sama i jego przyjaciół.",
+      "trailer": "https://www.youtube.com/embed/NvbfAFVXpZU"
+    },
+    {
+      "category": "Kino Konesera",
+      "title": "Małe miłości",
+      "date": "poniedziałek, 30 czerwca 2025",
+      "description": "Poruszająca historia o relacjach międzypokoleniowych i samotności.",
+      "trailer": "https://www.youtube.com/embed/3zxDYgw7s50"
+    },
+    {
+      "category": "Maraton Filmowy",
+      "title": "Maraton Władcy Pierścieni",
+      "date": "piątek, 22 sierpnia 2025",
+      "description": "Epoka podróż po Śródziemiu w filmowej trylogii Petera Jacksona.",
+      "trailer": "https://www.youtube.com/embed/x-1GwKtaq6Q"
+    },
+    {
+      "category": "Kino Kobiet",
+      "title": "Materialiści",
+      "date": "środa, 9 lipca 2025",
+      "description": "Komedia romantyczna o swatce, która spełnia marzenia klientów.",
+      "trailer": "https://www.youtube.com/embed/zwUTpFs8plo"
+    },
+    {
+      "category": "Kultura Dostępna",
+      "title": "Dziadku, wiejemy!",
+      "date": "czwartek, 3 lipca 2025",
+      "description": "Ciepła opowieść o relacji dziadka i córki oraz odwadze zmian.",
+      "trailer": "https://www.youtube.com/embed/LHrudBHu9sQ"
+    },
+    {
+      "category": "Helios dla Dzieci",
+      "title": "Basia. Mam swój świat",
+      "date": "sobota, 5 lipca 2025",
+      "description": "Przedpremierowe seanse przygód rezolutnej Basi.",
+      "trailer": "https://www.youtube.com/embed/e0Yaxpw6ErU"
+    },
+    {
+      "category": "Helios Anime",
+      "title": "Szopy w natarciu",
+      "date": "niedziela, 13 lipca 2025",
+      "description": "Ekologiczna przypowieść Studia Ghibli o przyjaźni z naturą.",
+      "trailer": "https://www.youtube.com/embed/FxyYjvdfHCs"
+    },
+    {
+      "category": "Helios Anime",
+      "title": "AKIRA",
+      "date": "środa, 16 lipca 2025",
+      "description": "Kultowy film anime o Neo Tokio po wojnie nuklearnej.",
+      "trailer": "https://www.youtube.com/embed/nA8KmHC2Z-g"
+    },
+    {
+      "category": "Helios na Scenie",
+      "title": "Dziewczyna z Kolonii",
+      "date": "sobota, 19 lipca 2025",
+      "description": "Muzyczna podróż z jazzowym pianistą w tle.",
+      "trailer": "https://www.youtube.com/embed/A0njNKEdtrk"
+    },
+    {
+      "category": "Maraton Filmowy",
+      "title": "Harry Potter: Mini Maraton cz. 1–2",
+      "date": "piątek, 4 lipca 2025",
+      "description": "Pokazy Kamień Filozoficzny i Komnata Tajemnic na dużym ekranie.",
+      "trailer": "https://www.youtube.com/embed/P0O5AtvPHmM"
+    },
+    {
+      "category": "Maraton Filmowy",
+      "title": "Harry Potter: Mini Maraton cz. 3–4",
+      "date": "piątek, 18 lipca 2025",
+      "description": "Seanse Więzień Azkabanu i Czara Ognia dla fanów przygód czarodziejów.",
+      "trailer": "https://www.youtube.com/embed/mT29ooZLHrY"
+    },
+    {
+      "category": "Maraton Filmowy",
+      "title": "Harry Potter: Mini Maraton cz. 5–6",
+      "date": "piątek, 1 sierpnia 2025",
+      "description": "Pokazy Zakon Feniksa i Księcia Półkrwi w klimatycznej atmosferze.",
+      "trailer": "https://www.youtube.com/embed/tAiy66Xrsz4"
+    },
+    {
+      "category": "Maraton Filmowy",
+      "title": "Harry Potter: Mini Maraton cz. 7–8",
+      "date": "piątek, 15 sierpnia 2025",
+      "description": "Finałowa odsłona maratonu z Insygniami Śmierci cz. 1 i 2.",
+      "trailer": "https://www.youtube.com/embed/MxqsmsA8y5k"
+    }
   ],
   "premieres": [
-    {"title":"Jurassic World: Odrodzenie","date":"od 4 lipca 2025","description":"Najnowsza odsłona serii z dinozaurami w tropikalnym parku."},
-    {"title":"Brzydka siostra","date":"od 4 lipca 2025","description":"Polska komedia o akceptacji siebie i relacjach rodzinnych."},
-    {"title":"Heidi ratuje rysia","date":"od 4 lipca 2025","description":"Klasyczna przygoda Heidi w ratowaniu dzikiej fauny Alp."},
-    {"title":"Superman","date":"od 11 lipca 2025","description":"Reboot kultowego bohatera DC w nowej, epickiej historii."},
-    {"title":"Basia. Mam swój świat","date":"od 11 lipca 2025","description":"Kinowa premiera przygód pięcioletniej Basi."},
-    {"title":"Smerfy. Wielki film","date":"od 18 lipca 2025","description":"Wyprawa Smerfów do prawdziwego świata w nowej animacji."},
-    {"title":"Koszmar minionego lata","date":"od 18 lipca 2025","description":"Horror, który obudzi wspomnienia kultowej serii z lat 90."},
-    {"title":"Fantastyczna 4: Pierwsze kroki","date":"od 25 lipca 2025","description":"Opowieść o rodzinie Marvela w retro scenerii lat 60."},
-    {"title":"O psie, który jeździł koleją 2","date":"od 8 sierpnia 2025","description":"Ciepła opowieść o przyjaźni człowieka i psa."}
+    {
+      "title": "Jurassic World: Odrodzenie",
+      "date": "od 4 lipca 2025",
+      "description": "Najnowsza odsłona serii z dinozaurami w tropikalnym parku.",
+      "trailer": "https://www.youtube.com/embed/fb5ELWi-ekk"
+    },
+    {
+      "title": "Brzydka siostra",
+      "date": "od 4 lipca 2025",
+      "description": "Polska komedia o akceptacji siebie i relacjach rodzinnych.",
+      "trailer": "https://www.youtube.com/embed/ws4NOZxaflo"
+    },
+    {
+      "title": "Heidi ratuje rysia",
+      "date": "od 4 lipca 2025",
+      "description": "Klasyczna przygoda Heidi w ratowaniu dzikiej fauny Alp.",
+      "trailer": "https://www.youtube.com/embed/Nieeiy4qABs"
+    },
+    {
+      "title": "Superman",
+      "date": "od 11 lipca 2025",
+      "description": "Reboot kultowego bohatera DC w nowej, epickiej historii.",
+      "trailer": "https://www.youtube.com/embed/pngEIbGpozw"
+    },
+    {
+      "title": "Basia. Mam swój świat",
+      "date": "od 11 lipca 2025",
+      "description": "Kinowa premiera przygód pięcioletniej Basi.",
+      "trailer": "https://www.youtube.com/embed/e0Yaxpw6ErU"
+    },
+    {
+      "title": "Smerfy. Wielki film",
+      "date": "od 18 lipca 2025",
+      "description": "Wyprawa Smerfów do prawdziwego świata w nowej animacji.",
+      "trailer": "https://www.youtube.com/embed/lgvX9IWrQNY"
+    },
+    {
+      "title": "Koszmar minionego lata",
+      "date": "od 18 lipca 2025",
+      "description": "Horror, który obudzi wspomnienia kultowej serii z lat 90.",
+      "trailer": "https://www.youtube.com/embed/VJu7BKi31Fw"
+    },
+    {
+      "title": "Fantastyczna 4: Pierwsze kroki",
+      "date": "od 25 lipca 2025",
+      "description": "Opowieść o rodzinie Marvela w retro scenerii lat 60.",
+      "trailer": "https://www.youtube.com/embed/wZYQUpC2BuQ"
+    },
+    {
+      "title": "O psie, który jeździł koleją 2",
+      "date": "od 8 sierpnia 2025",
+      "description": "Ciepła opowieść o przyjaźni człowieka i psa.",
+      "trailer": "https://www.youtube.com/embed/R9dKxwKrsCM"
+    }
   ],
   "repertoire": [
-    {"title":"F1","version":"2D","description":"Dramat sportowy o kulisach Formuły 1."},
-    {"title":"M3GAN 2.0","version":"2D","description":"Thriller o zabójczej lalce android."},
-    {"title":"Jak wytresować smoka","version":"2D","description":"Animowana opowieść o przyjaźni chłopca ze smokiem."},
-    {"title":"Lilo i Stitch","version":"2D","description":"Kultowa komedia familijna z kosmicznym przyjacielem."},
-    {"title":"28 lat później","version":"2D","description":"Kontynuacja postapokaliptycznej opowieści o zombiakach."},
-    {"title":"Elio","version":"2D","description":"Animacja o chłopcu marzącym o kosmicznych podróżach."},
-    {"title":"Materialiści","version":"2D","description":"Romantyczna komedia o miłości i randkowaniu."},
-    {"title":"Rytuał","version":"2D","description":"Horror o mrocznych obrzędach w głuszy lasu."}
+    {
+      "title": "F1",
+      "version": "2D",
+      "description": "Dramat sportowy o kulisach Formuły 1.",
+      "trailer": "https://www.youtube.com/embed/qOVZXh8xpC4"
+    },
+    {
+      "title": "M3GAN 2.0",
+      "version": "2D",
+      "description": "Thriller o zabójczej lalce android.",
+      "trailer": "https://www.youtube.com/embed/55X8iSN3xA8"
+    },
+    {
+      "title": "Jak wytresować smoka",
+      "version": "2D",
+      "description": "Animowana opowieść o przyjaźni chłopca ze smokiem.",
+      "trailer": "https://www.youtube.com/embed/WlavI9919bs"
+    },
+    {
+      "title": "Lilo i Stitch",
+      "version": "2D",
+      "description": "Kultowa komedia familijna z kosmicznym przyjacielem.",
+      "trailer": "https://www.youtube.com/embed/VWqJifMMgZE"
+    },
+    {
+      "title": "28 lat później",
+      "version": "2D",
+      "description": "Kontynuacja postapokaliptycznej opowieści o zombiakach.",
+      "trailer": "https://www.youtube.com/embed/mcvLKldPM08"
+    },
+    {
+      "title": "Elio",
+      "version": "2D",
+      "description": "Animacja o chłopcu marzącym o kosmicznych podróżach.",
+      "trailer": "https://www.youtube.com/embed/ETVi5_cnnaE"
+    },
+    {
+      "title": "Materialiści",
+      "version": "2D",
+      "description": "Romantyczna komedia o miłości i randkowaniu.",
+      "trailer": "https://www.youtube.com/embed/zwUTpFs8plo"
+    },
+    {
+      "title": "Rytuał",
+      "version": "2D",
+      "description": "Horror o mrocznych obrzędach w głuszy lasu.",
+      "trailer": "https://www.youtube.com/embed/XOTGjxMb2Jo"
+    }
   ]
 }

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,13 @@
   <main>
     <section id="events" class="active">
       <h2>Wydarzenia</h2>
+      <div class="sort-control">
+        <label for="sort-select">Sortuj:</label>
+        <select id="sort-select">
+          <option value="default">Domyślnie</option>
+          <option value="date">Według daty</option>
+        </select>
+      </div>
       <ul id="events-list"></ul>
     </section>
     <section id="premieres">
@@ -34,6 +41,7 @@
       <span class="close">×</span>
       <h3 id="modal-title"></h3>
       <p id="modal-description"></p>
+      <div id="modal-trailer" class="trailer"></div>
     </div>
   </div>
 
@@ -49,49 +57,85 @@
       return r.ok ? await r.json() : [];
     }
 
-    function openModal(title, desc) {
+    function openModal(title, desc, trailer) {
       document.getElementById('modal-title').textContent = title;
       document.getElementById('modal-description').textContent = desc || 'Brak opisu.';
+      const container = document.getElementById('modal-trailer');
+      if (trailer) {
+        container.innerHTML = `<iframe src="${trailer}" frameborder="0" allowfullscreen></iframe>`;
+        container.style.display = 'block';
+      } else {
+        container.innerHTML = '';
+        container.style.display = 'none';
+      }
       document.getElementById('modal').classList.add('active');
     }
 
-    function createItem(item, withVer) {
+    const months = {
+      'stycznia': 0, 'lutego': 1, 'marca': 2, 'kwietnia': 3,
+      'maja': 4, 'czerwca': 5, 'lipca': 6, 'sierpnia': 7,
+      'września': 8, 'października': 9, 'listopada': 10, 'grudnia': 11
+    };
+
+    function parseDate(str) {
+      const m = str.match(/(\d{1,2})\s+(stycznia|lutego|marca|kwietnia|maja|czerwca|lipca|sierpnia|września|października|listopada|grudnia)\s+(\d{4})/);
+      if (!m) return new Date(0);
+      return new Date(parseInt(m[3], 10), months[m[2]], parseInt(m[1], 10));
+    }
+
+    function createItem(item, withVer, showCategory = false) {
       const li = document.createElement('li');
-      const text = withVer ? `${item.title} (${item.version})` : `${item.title} – ${item.date}`;
+      let text;
+      if (withVer) {
+        text = `${item.title} (${item.version})`;
+      } else if (showCategory) {
+        text = `${item.title} – ${item.category} – ${item.date}`;
+      } else {
+        text = `${item.title} – ${item.date}`;
+      }
       li.textContent = text;
       li.classList.add('item');
 
       li.addEventListener('click', () => {
-        openModal(item.title, item.description || 'Brak opisu.');
+        openModal(item.title, item.description || 'Brak opisu.', item.trailer);
       });
 
       return li;
     }
 
     async function render() {
+      const sortByDate = document.getElementById('sort-select').value === 'date';
       for (const e of endpoints) {
         const list = await fetchData(e.url);
         const ul = document.getElementById(e.id);
         ul.innerHTML = '';
 
         if (e.id === 'events-list') {
-          const grouped = {};
-          list.forEach(event => {
-            if (!grouped[event.category]) grouped[event.category] = [];
-            grouped[event.category].push(event);
-          });
-
-          Object.keys(grouped).forEach(category => {
-            const catHeader = document.createElement('li');
-            catHeader.textContent = category;
-            catHeader.classList.add('bold-category');
-            ul.appendChild(catHeader);
-
-            grouped[category].forEach(event => {
-              ul.appendChild(createItem(event, false));
+          if (sortByDate) {
+            list.sort((a, b) => parseDate(a.date) - parseDate(b.date));
+            list.forEach(event => ul.appendChild(createItem(event, false, true)));
+          } else {
+            const grouped = {};
+            list.forEach(event => {
+              if (!grouped[event.category]) grouped[event.category] = [];
+              grouped[event.category].push(event);
             });
-          });
+
+            Object.keys(grouped).forEach(category => {
+              const catHeader = document.createElement('li');
+              catHeader.textContent = category;
+              catHeader.classList.add('bold-category');
+              ul.appendChild(catHeader);
+
+              grouped[category].forEach(event => {
+                ul.appendChild(createItem(event, false));
+              });
+            });
+          }
         } else {
+          if (sortByDate && list.length && list[0].date) {
+            list.sort((a, b) => parseDate(a.date) - parseDate(b.date));
+          }
           list.forEach(i => ul.appendChild(createItem(i, e.ver)));
         }
       }
@@ -119,11 +163,12 @@
       });
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
-      render();
-      setupTabs();
-      setupModal();
-    });
+      document.addEventListener('DOMContentLoaded', () => {
+        render();
+        setupTabs();
+        setupModal();
+        document.getElementById('sort-select').addEventListener('change', render);
+      });
   </script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -16,7 +16,7 @@
 
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background: var(--bg);
+  background: linear-gradient(to right, #eef2ff, #ffffff);
   color: var(--text);
   overflow-x: hidden;
   line-height: 1.5;
@@ -95,15 +95,19 @@ ul {
 }
 
 li.item {
-  padding: .7rem 0;
+  padding: .8rem 1rem;
+  margin-bottom: .7rem;
   cursor: pointer;
-  border-bottom: 1px solid #ddd;
-  transition: background 0.2s;
+  border: 1px solid #ddd;
+  border-radius: var(--radius);
+  background: var(--card);
+  transition: background 0.2s, transform 0.2s;
 }
 
 li.item:hover {
   background-color: #f7f7f7;
   color: var(--accent);
+  transform: scale(1.02);
 }
 
 li.bold-category {
@@ -113,6 +117,14 @@ li.bold-category {
   padding-left: 0.5rem;
   background: #fff9e5;
   border-radius: 4px;
+}
+
+.sort-control {
+  margin-bottom: 1rem;
+}
+
+.sort-control label {
+  margin-right: .5rem;
 }
 
 .modal {
@@ -140,6 +152,18 @@ li.bold-category {
   position: relative;
   box-shadow: var(--shadow);
   animation: scaleIn 0.3s ease;
+}
+
+.trailer {
+  margin-top: 1rem;
+}
+
+.trailer iframe {
+  width: 100%;
+  height: 315px;
+  border: none;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
 }
 
 .modal-content .close {

--- a/server.js
+++ b/server.js
@@ -13,7 +13,8 @@ app.get('/api/events', (req, res) => {
     category: event.category,
     title: event.title,
     date: event.date,
-    description: event.description || 'Brak opisu.'
+    description: event.description || 'Brak opisu.',
+    trailer: event.trailer
   })));
 });
 
@@ -21,7 +22,8 @@ app.get('/api/premieres', (req, res) => {
   res.json(data.premieres.map(premiere => ({
     title: premiere.title,
     date: premiere.date,
-    description: premiere.description || 'Brak opisu.'
+    description: premiere.description || 'Brak opisu.',
+    trailer: premiere.trailer
   })));
 });
 
@@ -29,7 +31,8 @@ app.get('/api/repertoire', (req, res) => {
   res.json(data.repertoire.map(movie => ({
     title: movie.title,
     version: movie.version,
-    description: movie.description || 'Brak opisu.'
+    description: movie.description || 'Brak opisu.',
+    trailer: movie.trailer
   })));
 });
 


### PR DESCRIPTION
## Summary
- looked up missing trailers via DuckDuckGo
- replaced placeholders in `data.json`
- add ability to sort all events together when sorting by date

## Testing
- `node server.js > /tmp/server.log 2>&1 &`
- `cat /tmp/server.log`
- `curl -s http://localhost:3000/api/events | head -c 80`
- `curl -s http://localhost:3000/api/premieres | head -c 80`


------
https://chatgpt.com/codex/tasks/task_e_6861103094ec8329adae0ee14c15bd7a